### PR TITLE
Add Vagrant support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,3 +113,7 @@ venv.bak/
 
 # Powerpoint backups
 ~$*
+
+# Vagrant temporary files
+.vagrant
+

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,52 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Vagrantfile API/syntax version
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.require_version ">= 1.5.0"
+
+$install_reqs = <<SCRIPT
+  apt update
+  apt-get install -y python3-venv
+SCRIPT
+
+$prepare_venv = <<SCRIPT
+  cd
+  python3 -m venv venv
+  source venv/bin/activate
+  pip install --upgrade pip
+  pip install -r /vagrant/requirements.txt
+SCRIPT
+
+$venv_on_login = <<SCRIPT
+  cat <<EOT >> ~/.profile
+
+# activate venv by default
+if [ -f ~/venv/bin/activate ]; then
+    . ~/venv/bin/activate
+fi
+EOT
+  # make a symlink to conveniently get to top level
+  [ -e ~/rift-python ] || ln -s /vagrant ~/rift-python
+SCRIPT
+
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+
+  config.vm.define "ubuntu" do |ubuntu|
+    ubuntu.vm.box = "ubuntu/xenial64"
+    ubuntu.vm.box_check_update = false
+    ubuntu.vm.hostname = "xenialvm"
+
+    ubuntu.vm.provider :virtualbox do |vb|
+      vb.cpus = 2
+      vb.customize ["modifyvm", :id, "--memory", "1024"]
+      vb.customize ["modifyvm", :id, "--nictype1", "virtio"]
+    end
+
+    ubuntu.vm.provision "install_reqs", type: "shell", inline: $install_reqs
+    ubuntu.vm.provision "prepare_venv", type: "shell", inline: $prepare_venv, privileged: false
+    ubuntu.vm.provision "venv_on_login", type: "shell", inline: $venv_on_login, privileged: false
+  end
+end

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -3,6 +3,7 @@
 Installation instructions for:
 
 * [Ubuntu Linux on AWS](#ubuntu-linux-on-aws)
+* [Ubuntu Linux on local VM via Vagrant](#ubuntu-linux-on-local-vm-via-vagrant)
 
 ## Ubuntu Linux on AWS
 
@@ -176,3 +177,36 @@ For those interested, here is the list of dependency modules:
 | netifaces | Cross-platform portable code for retrieving information about interfaces and their addresses |
 | pyyaml | Parse Yet Another Markup Language (YAML) files |
 | cerberus | validate whether the data stored in a YAML file conforms to a data model (schema) |
+
+## Ubuntu Linux on local VM via Vagrant
+
+Using the Vagrantfile located in this repository, you can create and provision a local virtual machine to run rift-python
+
+### Install local hypervisor that is compatible with Vagrant
+
+For Mac users, the easiest and widely tested choice is [Virtual Box](https://www.virtualbox.org/)
+
+Note: You can also use Vagrant to prepare VM that is not local, but that is not documented here. For more info on using
+other providers such as AWS, visit [https://www.vagrantup.com/intro/getting-started/providers.html](https://www.vagrantup.com/intro/getting-started/providers.html)
+
+### Install Vagrant
+
+Download an follow instructions located at [https://www.vagrantup.com/downloads.html](https://www.vagrantup.com/downloads.html)
+
+### Start VM via Vagrant
+
+cd to the top level directory of this repo -- where **Vagrantfile** is located -- and type
+
+```
+vagrant up
+```
+
+Once VM is provisioned, you can access it using all the well-documented Vagrant commands,
+such as
+
+```
+vagrant ssh
+vagrant halt
+vagrant destroy
+vagrant help
+```


### PR DESCRIPTION
Created Vagrantfile, so installation of rift-python can be completely
automated.

Updated doc/installation.md with info on provisioning VM using
Vagrant.