### PR TITLE
config_generator: add consistency check

### DIFF
--- a/rift/cli_session_handler.py
+++ b/rift/cli_session_handler.py
@@ -58,6 +58,7 @@ class CliSessionHandler:
         self._command_history = []
         self._command_history_pos = None
         self._next_commands = []
+        self._mode = "human"
         self.info("Open CLI session")
         self._telnet = (sock is not None)
         self._telnet_suppress_go_ahead = False
@@ -73,6 +74,12 @@ class CliSessionHandler:
             return self._sock.getpeername()[0] + ":" + str(self._sock.getpeername()[1])
         else:
             return "local"
+
+    def set_mode(self, mode):
+        self._mode = mode
+
+    def human_mode(self):
+        return self._mode == "human"
 
     def info(self, msg, *args):
         self._log.info("[%s] %s: %s" % (self.current_node_name(), self.peername(), msg), *args)
@@ -94,6 +101,12 @@ class CliSessionHandler:
 
     def tx_fd(self):
         return self._tx_fd
+
+    def print_table(self, tab):
+        if self._mode == "csv":
+            self.print(tab.to_csv_string())
+        else:
+            self.print(tab.to_string())
 
     def print(self, message, add_newline=True):
         if self._tx_fd is None:

--- a/rift/engine.py
+++ b/rift/engine.py
@@ -276,11 +276,17 @@ class Engine:
     def command_show_routes(self, cli_session):
         cli_session.current_node.command_show_routes(cli_session)
 
+    def command_show_routes_family(self, cli_session, parameters):
+        cli_session.current_node.command_show_routes_family(cli_session, parameters)
+
     def command_show_forwarding(self, cli_session):
         cli_session.current_node.command_show_forwarding(cli_session)
 
     def command_show_forwarding_prefix(self, cli_session, parameters):
         cli_session.current_node.command_show_forwarding_prefix(cli_session, parameters)
+
+    def command_show_forwarding_family(self, cli_session, parameters):
+        cli_session.current_node.command_show_forwarding_family(cli_session, parameters)
 
     def command_show_spf(self, cli_session):
         cli_session.current_node.command_show_spf(cli_session)
@@ -314,6 +320,9 @@ class Engine:
         cli_session.current_node.fsm.push_event(node.Node.Event.CHANGE_LOCAL_CONFIGURED_LEVEL,
                                                 level_symbol)
 
+    def command_set_cli_mode(self, cli_session, parameters):
+        cli_session.set_mode(parameters['cli-mode'].lower())
+
     def command_exit(self, cli_session):
         cli_session.close()
 
@@ -340,6 +349,7 @@ class Engine:
             },
             "$node": command_set_node,
             "$level": command_set_level,
+            "$cli-mode": command_set_cli_mode,
         },
         "show": {
             "engine": {
@@ -353,6 +363,7 @@ class Engine:
             "forwarding": {
                 "": command_show_forwarding,
                 "$prefix": command_show_forwarding_prefix,
+                "$family": command_show_forwarding_family,
             },
             "fsm": {
                 "lie": command_show_lie_fsm,
@@ -405,6 +416,7 @@ class Engine:
                     "": command_show_route_prefix,
                     "$owner": command_show_route_prefix_owner,
                 },
+                "$family": command_show_routes_family,
             },
             "spf": {
                 "": command_show_spf,

--- a/rift/kernel.py
+++ b/rift/kernel.py
@@ -411,8 +411,9 @@ class Kernel:
         if self.unsupported_platform_error(cli_session):
             return
         tab = self.cli_routes_table(table_nr)
-        cli_session.print("Kernel Routes:")
-        cli_session.print(tab.to_string())
+        if cli_session.human_mode():
+            cli_session.print("Kernel Routes:")
+        cli_session.print_table(tab)
 
     def cli_route_prefix_table(self, table_nr, prefix):
         prefix_str = packet_common.ip_prefix_str(prefix)

--- a/rift/node.py
+++ b/rift/node.py
@@ -1234,14 +1234,21 @@ class Node:
         self.command_show_routes_af(cli_session, constants.ADDRESS_FAMILY_IPV4)
         self.command_show_routes_af(cli_session, constants.ADDRESS_FAMILY_IPV6)
 
+    def command_show_routes_family(self, cli_session, parameters):
+        if parameters["family"].lower() == "ipv4":
+            self.command_show_routes_af(cli_session, constants.ADDRESS_FAMILY_IPV4)
+        else:
+            self.command_show_routes_af(cli_session, constants.ADDRESS_FAMILY_IPV6)
+
     def command_show_routes_af(self, cli_session, address_family):
-        cli_session.print(constants.address_family_str(address_family) + " Routes:")
+        if cli_session.human_mode():
+            cli_session.print(constants.address_family_str(address_family) + " Routes:")
         if address_family == constants.ADDRESS_FAMILY_IPV4:
             tab = self._ipv4_rib.cli_table()
         else:
             assert address_family == constants.ADDRESS_FAMILY_IPV6
             tab = self._ipv6_rib.cli_table()
-        cli_session.print(tab.to_string())
+        cli_session.print_table(tab)
 
     def command_show_forwarding_prefix(self, cli_session, parameters):
         prefix = self.get_prefix_param(cli_session, parameters)
@@ -1258,20 +1265,28 @@ class Node:
         tab = table.Table()
         tab.add_row(route.Route.cli_summary_headers())
         tab.add_row(rte.cli_summary_attributes())
-        cli_session.print(tab.to_string())
+        cli_session.print_table(tab)
 
     def command_show_forwarding(self, cli_session):
         self.command_show_forwarding_af(cli_session, constants.ADDRESS_FAMILY_IPV4)
         self.command_show_forwarding_af(cli_session, constants.ADDRESS_FAMILY_IPV6)
 
+    def command_show_forwarding_family(self, cli_session, parameters):
+        if parameters["family"].lower() == "ipv4":
+            self.command_show_forwarding_af(cli_session, constants.ADDRESS_FAMILY_IPV4)
+        else:
+            self.command_show_forwarding_af(cli_session, constants.ADDRESS_FAMILY_IPV6)
+
     def command_show_forwarding_af(self, cli_session, address_family):
-        cli_session.print(constants.address_family_str(address_family) + " Routes:")
+        if cli_session.human_mode():
+            cli_session.print(constants.address_family_str(address_family) + " Routes:")
+
         if address_family == constants.ADDRESS_FAMILY_IPV4:
             tab = self._ipv4_fib.cli_table()
         else:
             assert address_family == constants.ADDRESS_FAMILY_IPV6
             tab = self._ipv6_fib.cli_table()
-        cli_session.print(tab.to_string())
+        cli_session.print_table(tab)
 
     def command_show_spf(self, cli_session):
         cli_session.print("SPF Statistics:")

--- a/rift/table.py
+++ b/rift/table.py
@@ -1,4 +1,7 @@
 from enum import Enum
+import csv
+import io
+import itertools
 
 class Table:
 
@@ -91,3 +94,24 @@ class Table:
         if not self._separators:
             table_str += self.separator_string()
         return table_str
+
+    def to_csv_string(self):
+        output = io.StringIO()
+        writer = csv.writer(output)
+
+        if not self._rows:
+            return ""
+
+        for i, col in enumerate(self._rows[0]):
+            if isinstance(col, list):
+                self._rows[0][i] = ' '.join(col)
+        writer.writerow(self._rows[0])
+
+        for row in self._rows[1:]:
+            for i, col in enumerate(row):
+                if not isinstance(col, list):
+                    row[i] = [col]
+            for prod in itertools.product(*row):
+                writer.writerow(prod)
+
+        return output.getvalue()


### PR DESCRIPTION
This commit adds two consistency checks to config_generator tool.
First, we check whether RIB and FIB as reported by show routes
and show forwarding respectively are identical.
Second, we check whether RIFT FIB and kernel FIBs are identical.

Screen scraping for multiple next-hops would be very difficult with
the tables, so I added an CLI command "set cli-mode csv" to specify
that tables should be displayed as CSVs (which is much easier to
parse). In order to a table to be displayed in CSV, one should use
print_table() instead of print().

To make the parsing even easier, I added family options to show
routes and show forwarding, so it's possible to display routes/
forwarding entries for a selected family only.