### PR TITLE
Add missing hashbang and virtualenv to scripts generated by config_generator.py

### DIFF
--- a/tools/config_generator.py
+++ b/tools/config_generator.py
@@ -568,7 +568,7 @@ class Node:
         print('echo "{}"'.format(progress_msg), file=file)
         ns_name = NETNS_PREFIX + str(self.global_node_id)
         port_file = "/tmp/rift-python-telnet-port-" + self.name
-        print("ip netns exec {} python3 rift "
+        print("ip netns exec {} env/bin/python3 rift "
               "--ipv4-multicast-loopback-disable "
               "--ipv6-multicast-loopback-disable "
               "--telnet-port-file {} {} >/dev/null 2>&1 &"
@@ -1174,6 +1174,7 @@ class Fabric:
         file_name = dir_name + '/' + script_file_name
         try:
             with open(file_name, 'w') as file:
+                print("#!/bin/bash", file=file)
                 write_script_function(file)
         except IOError:
             fatal_error('Could not open script file "{}"'.format(file_name))


### PR DESCRIPTION
A couple of nits that I found going through the setup and running this:

1. There is no hashbang in the start.sh script, but bash specific [[ is used giving a number of `[[: not found` errors.

2. The scripts root due to the veth and netns usage, but with sudo when it gets to starting RIFT it fails as the virtualenv isn't carried over and so it can't find the modules. Added `env/bin` to the path here.

```(env) root@krisvm:/home/kjp/rift-python# ./tools/pre-commit-checks

------------------------------------
Your code has been rated at 10.00/10


------------------------------------
Your code has been rated at 10.00/10


------------------------------------
Your code has been rated at 10.00/10

========================================= test session starts ==========================================
platform linux -- Python 3.6.7, pytest-3.6.4, py-1.5.4, pluggy-0.7.1
rootdir: /home/kjp/rift-python, inifile:
plugins: cov-2.5.1
collected 100 items

tests/test_config_generator.py ....                                                              [  4%]
tests/test_constants.py ....                                                                     [  8%]
tests/test_fsm.py ......                                                                         [ 14%]
tests/test_kernel.py .........                                                                   [ 23%]
tests/test_next_hop.py ..                                                                        [ 25%]
tests/test_node_flood.py .........                                                               [ 34%]
tests/test_node_flood_repeater_election.py ..........                                            [ 44%]
tests/test_packet_common.py ...........                                                          [ 55%]
tests/test_real_topology.py .                                                                    [ 56%]
tests/test_rib_fib.py ...........                                                                [ 67%]
tests/test_stats.py ........                                                                     [ 75%]
tests/test_sys_2n_l0_l1.py .                                                                     [ 76%]
tests/test_sys_2n_l0_l2.py .                                                                     [ 77%]
tests/test_sys_2n_l1_l3.py .                                                                     [ 78%]
tests/test_sys_2n_un_l0.py .                                                                     [ 79%]
tests/test_sys_2n_un_l1.py .                                                                     [ 80%]
tests/test_sys_2n_un_l2.py .                                                                     [ 81%]
tests/test_sys_3n_l0_l1_l2.py .                                                                  [ 82%]
tests/test_sys_cli_commands.py .                                                                 [ 83%]
tests/test_sys_standalone.py .                                                                   [ 84%]
tests/test_table.py ....                                                                         [ 88%]
tests/test_telnet.py ......                                                                      [ 94%]
tests/test_timer.py .....                                                                        [ 99%]
tests/test_visualize_log.py .                                                                    [100%]

----------- coverage: platform linux, python 3.6.7-final-0 -----------
Name                                         Stmts   Miss  Cover
----------------------------------------------------------------
rift/__main__.py                                60      9    85%
rift/cli_listen_handler.py                      26      3    88%
rift/cli_session_handler.py                    398     23    94%
rift/config.py                                 167     35    79%
rift/constants.py                               51      6    88%
rift/engine.py                                 250     24    90%
rift/fib.py                                     46      4    91%
rift/fsm.py                                    284     10    96%
rift/interface.py                             1104    249    77%
rift/kernel.py                                 340    106    69%
rift/neighbor.py                                42      2    95%
rift/next_hop.py                                40     19    52%
rift/node.py                                  1702    365    79%
rift/offer.py                                   26      0   100%
rift/packet_common.py                          350     66    81%
rift/rib.py                                    133     17    87%
rift/route.py                                   16      0   100%
rift/scheduler.py                               43      8    81%
rift/spf_dest.py                                75     13    83%
rift/stats.py                                  146      9    94%
rift/table.py                                   97     17    82%
rift/timer.py                                   82     11    87%
rift/udp_rx_handler.py                         183     47    74%
rift/utils.py                                   28      2    93%
tests/__init__.py                                3      0   100%
tests/log_expect_session.py                    141     25    82%
tests/rift_expect_session.py                   187     31    83%
tests/test_config_generator.py                  50      0   100%
tests/test_constants.py                         24      0   100%
tests/test_fsm.py                               94      0   100%
tests/test_kernel.py                            87      6    93%
tests/test_next_hop.py                          28      0   100%
tests/test_node_flood.py                       299      3    99%
tests/test_node_flood_repeater_election.py     231      0   100%
tests/test_packet_common.py                     88      0   100%
tests/test_real_topology.py                      6      1    83%
tests/test_rib_fib.py                          316      0   100%
tests/test_stats.py                            243      0   100%
tests/test_sys_2n_l0_l1.py                      93      0   100%
tests/test_sys_2n_l0_l2.py                      75      0   100%
tests/test_sys_2n_l1_l3.py                      44      0   100%
tests/test_sys_2n_un_l0.py                      42      0   100%
tests/test_sys_2n_un_l1.py                      73      0   100%
tests/test_sys_2n_un_l2.py                      73      0   100%
tests/test_sys_3n_l0_l1_l2.py                  241      0   100%
tests/test_sys_cli_commands.py                 285      7    98%
tests/test_sys_standalone.py                    17      0   100%
tests/test_table.py                             32      0   100%
tests/test_telnet.py                           461     15    97%
tests/test_timer.py                            120      0   100%
tests/test_visualize_log.py                     25      1    96%
----------------------------------------------------------------
TOTAL                                         9067   1134    87%


===================================== 100 passed in 241.68 seconds =====================================
All good; you can commit.
(env) root@krisvm:/home/kjp/rift-python#
```