### PR TITLE
Add Negative Prefixes in SPF run

### DIFF
--- a/rift/node.py
+++ b/rift/node.py
@@ -2783,7 +2783,7 @@ class Node:
                               special_for_neg_disagg)
         self.spf_add_pos_disagg_prefixes(node_system_id, node_cost, candidates, spf_direction,
                                          special_for_neg_disagg)
-        self.spf_add_neg_disagg_prefixes(node_system_id, candidates, spf_direction,
+        self.spf_add_neg_disagg_prefixes(node_system_id, node_cost, candidates, spf_direction,
                                          special_for_neg_disagg)
 
     def spf_add_neighbor_candidates(self, node_system_id, node_cost, node_ties, candidates,
@@ -2804,7 +2804,10 @@ class Node:
             if self.is_neighbor_bidirectional(node_system_id, nbr_system_id, nbr_tie_element,
                                               spf_direction, special_for_neg_disagg):
                 # We have found a feasible path to the neighbor node; is the best path?
-                cost = node_cost + nbr_tie_element.cost
+                if nbr_tie_element.cost >= common.constants.infinite_distance:
+                    cost = common.constants.infinite_distance
+                else:
+                    cost = node_cost + nbr_tie_element.cost
                 destination = spf_dest.make_node_dest(nbr_system_id, None, cost)
 
                 self.spf_consider_candidate_dest(destination, nbr_tie_element, node_system_id,
@@ -2837,7 +2840,7 @@ class Node:
                                          pos_disagg_prefixes,
                                          is_pos_disagg=True, is_neg_disagg=False)
 
-    def spf_add_neg_disagg_prefixes(self, node_sysid, candidates, spf_direction,
+    def spf_add_neg_disagg_prefixes(self, node_sysid, node_cost, candidates, spf_direction,
                                     special_for_neg_disagg):
         prefix_ties = self.ties_of_type(
             direction=self.spf_use_tie_direction(node_sysid, spf_direction),
@@ -2846,10 +2849,7 @@ class Node:
 
         for prefix_tie in prefix_ties:
             neg_disagg_prefixes = prefix_tie.element.negative_disaggregation_prefixes.prefixes
-            # Force node_cost = 0 since the prefix metric is infinite so
-            # we don't need to compute a real cost
-            # TODO: Ask to Bruno
-            self.spf_add_prefixes_common(node_sysid, 0, candidates, spf_direction,
+            self.spf_add_prefixes_common(node_sysid, node_cost, candidates, spf_direction,
                                          special_for_neg_disagg,
                                          neg_disagg_prefixes,
                                          is_pos_disagg=False, is_neg_disagg=True)
@@ -2860,7 +2860,10 @@ class Node:
             return
         for prefix, attributes in prefixes.items():
             tags = attributes.tags
-            cost = node_cost + attributes.metric
+            if attributes.metric >= common.constants.infinite_distance:
+                cost = common.constants.infinite_distance
+            else:
+                cost = node_cost + attributes.metric
             dest = spf_dest.make_prefix_dest(prefix, tags, cost, is_pos_disagg, is_neg_disagg)
             self.spf_consider_candidate_dest(dest, None, node_sysid, candidates,
                                              spf_direction, special_for_neg_disagg)

--- a/rift/node.py
+++ b/rift/node.py
@@ -2783,7 +2783,7 @@ class Node:
                               special_for_neg_disagg)
         self.spf_add_pos_disagg_prefixes(node_system_id, node_cost, candidates, spf_direction,
                                          special_for_neg_disagg)
-        self.spf_add_neg_disagg_prefixes(node_system_id, node_cost, candidates, spf_direction,
+        self.spf_add_neg_disagg_prefixes(node_system_id, candidates, spf_direction,
                                          special_for_neg_disagg)
 
     def spf_add_neighbor_candidates(self, node_system_id, node_cost, node_ties, candidates,
@@ -2837,7 +2837,7 @@ class Node:
                                          pos_disagg_prefixes,
                                          is_pos_disagg=True, is_neg_disagg=False)
 
-    def spf_add_neg_disagg_prefixes(self, node_sysid, node_cost, candidates, spf_direction,
+    def spf_add_neg_disagg_prefixes(self, node_sysid, candidates, spf_direction,
                                     special_for_neg_disagg):
         prefix_ties = self.ties_of_type(
             direction=self.spf_use_tie_direction(node_sysid, spf_direction),
@@ -2846,7 +2846,8 @@ class Node:
 
         for prefix_tie in prefix_ties:
             neg_disagg_prefixes = prefix_tie.element.negative_disaggregation_prefixes.prefixes
-            # Force node_cost = 0 since the prefix metric is infinite so we don't need to compute a real cost
+            # Force node_cost = 0 since the prefix metric is infinite so
+            # we don't need to compute a real cost
             # TODO: Ask to Bruno
             self.spf_add_prefixes_common(node_sysid, 0, candidates, spf_direction,
                                          special_for_neg_disagg,

--- a/rift/node.py
+++ b/rift/node.py
@@ -2804,10 +2804,7 @@ class Node:
             if self.is_neighbor_bidirectional(node_system_id, nbr_system_id, nbr_tie_element,
                                               spf_direction, special_for_neg_disagg):
                 # We have found a feasible path to the neighbor node; is the best path?
-                if nbr_tie_element.cost >= common.constants.infinite_distance:
-                    cost = common.constants.infinite_distance
-                else:
-                    cost = node_cost + nbr_tie_element.cost
+                cost = min(node_cost + nbr_tie_element.cost, common.constants.infinite_distance)
                 destination = spf_dest.make_node_dest(nbr_system_id, None, cost)
 
                 self.spf_consider_candidate_dest(destination, nbr_tie_element, node_system_id,
@@ -2860,10 +2857,7 @@ class Node:
             return
         for prefix, attributes in prefixes.items():
             tags = attributes.tags
-            if attributes.metric >= common.constants.infinite_distance:
-                cost = common.constants.infinite_distance
-            else:
-                cost = node_cost + attributes.metric
+            cost = min(node_cost + attributes.metric, common.constants.infinite_distance)
             dest = spf_dest.make_prefix_dest(prefix, tags, cost, is_pos_disagg, is_neg_disagg)
             self.spf_consider_candidate_dest(dest, None, node_sysid, candidates,
                                              spf_direction, special_for_neg_disagg)

--- a/rift/node.py
+++ b/rift/node.py
@@ -2783,6 +2783,8 @@ class Node:
                               special_for_neg_disagg)
         self.spf_add_pos_disagg_prefixes(node_system_id, node_cost, candidates, spf_direction,
                                          special_for_neg_disagg)
+        self.spf_add_neg_disagg_prefixes(node_system_id, node_cost, candidates, spf_direction,
+                                         special_for_neg_disagg)
 
     def spf_add_neighbor_candidates(self, node_system_id, node_cost, node_ties, candidates,
                                     spf_direction, special_for_neg_disagg):
@@ -2834,6 +2836,22 @@ class Node:
                                          special_for_neg_disagg,
                                          pos_disagg_prefixes,
                                          is_pos_disagg=True, is_neg_disagg=False)
+
+    def spf_add_neg_disagg_prefixes(self, node_sysid, node_cost, candidates, spf_direction,
+                                    special_for_neg_disagg):
+        prefix_ties = self.ties_of_type(
+            direction=self.spf_use_tie_direction(node_sysid, spf_direction),
+            system_id=node_sysid,
+            prefix_type=common.ttypes.TIETypeType.NegativeDisaggregationPrefixTIEType)
+
+        for prefix_tie in prefix_ties:
+            neg_disagg_prefixes = prefix_tie.element.negative_disaggregation_prefixes.prefixes
+            # Force node_cost = 0 since the prefix metric is infinite so we don't need to compute a real cost
+            # TODO: Ask to Bruno
+            self.spf_add_prefixes_common(node_sysid, 0, candidates, spf_direction,
+                                         special_for_neg_disagg,
+                                         neg_disagg_prefixes,
+                                         is_pos_disagg=False, is_neg_disagg=True)
 
     def spf_add_prefixes_common(self, node_sysid, node_cost, candidates, spf_direction,
                                 special_for_neg_disagg, prefixes, is_pos_disagg, is_neg_disagg):
@@ -3056,7 +3074,7 @@ class Node:
         fallen_leafs = {prefix: special_southbound_dests[prefix] for prefix in difference}
 
         for prefix in fallen_leafs.values():
-            prefix.set_negatively_disaggregate()
+            prefix.negatively_disaggregate = True
 
         self.regenerate_my_neg_disagg_tie(fallen_leafs)
 

--- a/rift/spf_dest.py
+++ b/rift/spf_dest.py
@@ -98,9 +98,6 @@ class SPFDest:
             self.tags = set()
         self.tags = self.tags.union(other_spf_destination.tags)
 
-    def set_negatively_disaggregate(self):
-        self.negatively_disaggregate = True
-
     @staticmethod
     def cli_summary_headers():
         return [

--- a/tests/rift_expect_session.py
+++ b/tests/rift_expect_session.py
@@ -232,23 +232,20 @@ class RiftExpectSession:
 
     def check_spf(self, node, expect_south_spf=None, expect_north_spf=None,
                   expect_south_ew_spf=None):
-        if expect_south_spf is None:
-            expect_south_spf = []
-        if expect_north_spf is None:
-            expect_north_spf = []
-        if expect_south_ew_spf is None:
-            expect_south_ew_spf = []
         self.sendline("set node {}".format(node))
         self.sendline("show spf")
-        self.expect("South SPF Destinations:")
-        for expected_row in expect_south_spf:
-            self.table_expect(expected_row)
-        self.expect("North SPF Destinations:")
-        for expected_row in expect_north_spf:
-            self.table_expect(expected_row)
-        self.expect(r"South SPF \(with East-West Links\) Destinations:")
-        for expected_row in expect_south_ew_spf:
-            self.table_expect(expected_row)
+        if expect_south_spf is not None:
+            self.expect("South SPF Destinations:")
+            for expected_row in expect_south_spf:
+                self.table_expect(expected_row)
+        if expect_north_spf is not None:
+            self.expect("North SPF Destinations:")
+            for expected_row in expect_north_spf:
+                self.table_expect(expected_row)
+        if expect_south_ew_spf is not None:
+            self.expect(r"South SPF \(with East-West Links\) Destinations:")
+            for expected_row in expect_south_ew_spf:
+                self.table_expect(expected_row)
 
     def check_spf_absent(self, node, direction, destination):
         self.sendline("set node {}".format(node))

--- a/tests/rift_expect_session.py
+++ b/tests/rift_expect_session.py
@@ -240,13 +240,13 @@ class RiftExpectSession:
             expect_south_ew_spf = []
         self.sendline("set node {}".format(node))
         self.sendline("show spf")
-        self.table_expect("South SPF Destinations:")
+        self.expect("South SPF Destinations:")
         for expected_row in expect_south_spf:
             self.table_expect(expected_row)
-        self.table_expect("North SPF Destinations:")
+        self.expect("North SPF Destinations:")
         for expected_row in expect_north_spf:
             self.table_expect(expected_row)
-        self.table_expect(r"South SPF \(with East-West Links\) Destinations:")
+        self.expect(r"South SPF \(with East-West Links\) Destinations:")
         for expected_row in expect_south_ew_spf:
             self.table_expect(expected_row)
 

--- a/tests/test_neg_disagg_spf_propagation.py
+++ b/tests/test_neg_disagg_spf_propagation.py
@@ -4,17 +4,23 @@ from rift_expect_session import RiftExpectSession
 
 def check_spine_positive_next_hops(res):
     res.check_spf(node="spine_2_1_1",
-                  expect_north_spf=[r"| 200.0.0.0/24 \(Disagg\) | 4 | 122 | | Positive | if3 .* | if3 .* |"])
+                  expect_north_spf=[
+                      r"| 200.0.0.0/24 \(Disagg\) | 4 | 122 | | Positive | if3 .* | if3 .* |"])
     res.check_spf(node="spine_2_1_1",
-                  expect_north_spf=[r"| 200.0.1.0/24 \(Disagg\) | 4 | 122 | | Positive | if3 .* | if3 .* |"])
+                  expect_north_spf=[
+                      r"| 200.0.1.0/24 \(Disagg\) | 4 | 122 | | Positive | if3 .* | if3 .* |"])
     res.check_spf(node="spine_3_1_1",
-                  expect_north_spf=[r"| 200.0.0.0/24 \(Disagg\) | 4 | 122 | | Positive | if3 .* | if3 .* |"])
+                  expect_north_spf=[
+                      r"| 200.0.0.0/24 \(Disagg\) | 4 | 122 | | Positive | if3 .* | if3 .* |"])
     res.check_spf(node="spine_3_1_1",
-                  expect_north_spf=[r"| 200.0.1.0/24 \(Disagg\) | 4 | 122 | | Positive | if3 .* | if3 .* |"])
+                  expect_north_spf=[
+                      r"| 200.0.1.0/24 \(Disagg\) | 4 | 122 | | Positive | if3 .* | if3 .* |"])
     res.check_spf(node="spine_4_1_1",
-                  expect_north_spf=[r"| 200.0.0.0/24 \(Disagg\) | 4 | 122 | | Positive | if3 .* | if3 .* |"])
+                  expect_north_spf=[
+                      r"| 200.0.0.0/24 \(Disagg\) | 4 | 122 | | Positive | if3 .* | if3 .* |"])
     res.check_spf(node="spine_4_1_1",
-                  expect_north_spf=[r"| 200.0.1.0/24 \(Disagg\) | 4 | 122 | | Positive | if3 .* | if3 .* |"])
+                  expect_north_spf=[
+                      r"| 200.0.1.0/24 \(Disagg\) | 4 | 122 | | Positive | if3 .* | if3 .* |"])
 
 
 def check_spine_negative_disagg_spf(res):
@@ -49,43 +55,56 @@ def check_spine_negative_disagg_spf(res):
                       r"| | | 122 | | | if3 .* | if3 .* |" % infinite_distance
                   ])
 
+
 def check_leaf_negative_next_hops(res):
     res.check_spf(node="leaf_2_0_1",
                   expect_north_spf=[
-                      r"| 200.0.0.0/24 \(Disagg\) | %d | 211 | | Negative | if0 .* | if0 .* |" % infinite_distance])
+                      r"| 200.0.0.0/24 \(Disagg\) | %d | 211 | | Negative | if0 .* | if0 .* |"
+                      % infinite_distance])
     res.check_spf(node="leaf_2_0_1",
                   expect_north_spf=[
-                      r"| 200.0.1.0/24 \(Disagg\) | %d | 211 | | Negative | if0 .* | if0 .* |" % infinite_distance])
+                      r"| 200.0.1.0/24 \(Disagg\) | %d | 211 | | Negative | if0 .* | if0 .* |"
+                      % infinite_distance])
     res.check_spf(node="leaf_2_0_2",
                   expect_north_spf=[
-                      r"| 200.0.0.0/24 \(Disagg\) | %d | 211 | | Negative | if0 .* | if0 .* |" % infinite_distance])
+                      r"| 200.0.0.0/24 \(Disagg\) | %d | 211 | | Negative | if0 .* | if0 .* |"
+                      % infinite_distance])
     res.check_spf(node="leaf_2_0_2",
                   expect_north_spf=[
-                      r"| 200.0.1.0/24 \(Disagg\) | %d | 211 | | Negative | if0 .* | if0 .* |" % infinite_distance])
+                      r"| 200.0.1.0/24 \(Disagg\) | %d | 211 | | Negative | if0 .* | if0 .* |"
+                      % infinite_distance])
     res.check_spf(node="leaf_3_0_1",
                   expect_north_spf=[
-                      r"| 200.0.0.0/24 \(Disagg\) | %d | 311 | | Negative | if0 .* | if0 .* |" % infinite_distance])
+                      r"| 200.0.0.0/24 \(Disagg\) | %d | 311 | | Negative | if0 .* | if0 .* |"
+                      % infinite_distance])
     res.check_spf(node="leaf_3_0_1",
                   expect_north_spf=[
-                      r"| 200.0.1.0/24 \(Disagg\) | %d | 311 | | Negative | if0 .* | if0 .* |" % infinite_distance])
+                      r"| 200.0.1.0/24 \(Disagg\) | %d | 311 | | Negative | if0 .* | if0 .* |"
+                      % infinite_distance])
     res.check_spf(node="leaf_3_0_2",
                   expect_north_spf=[
-                      r"| 200.0.0.0/24 \(Disagg\) | %d | 311 | | Negative | if0 .* | if0 .* |" % infinite_distance])
+                      r"| 200.0.0.0/24 \(Disagg\) | %d | 311 | | Negative | if0 .* | if0 .* |"
+                      % infinite_distance])
     res.check_spf(node="leaf_3_0_2",
                   expect_north_spf=[
-                      r"| 200.0.1.0/24 \(Disagg\) | %d | 311 | | Negative | if0 .* | if0 .* |" % infinite_distance])
+                      r"| 200.0.1.0/24 \(Disagg\) | %d | 311 | | Negative | if0 .* | if0 .* |"
+                      % infinite_distance])
     res.check_spf(node="leaf_4_0_1",
                   expect_north_spf=[
-                      r"| 200.0.0.0/24 \(Disagg\) | %d | 411 | | Negative | if0 .* | if0 .* |" % infinite_distance])
+                      r"| 200.0.0.0/24 \(Disagg\) | %d | 411 | | Negative | if0 .* | if0 .* |"
+                      % infinite_distance])
     res.check_spf(node="leaf_4_0_1",
                   expect_north_spf=[
-                      r"| 200.0.1.0/24 \(Disagg\) | %d | 411 | | Negative | if0 .* | if0 .* |" % infinite_distance])
+                      r"| 200.0.1.0/24 \(Disagg\) | %d | 411 | | Negative | if0 .* | if0 .* |"
+                      % infinite_distance])
     res.check_spf(node="leaf_4_0_2",
                   expect_north_spf=[
-                      r"| 200.0.0.0/24 \(Disagg\) | %d | 411 | | Negative | if0 .* | if0 .* |" % infinite_distance])
+                      r"| 200.0.0.0/24 \(Disagg\) | %d | 411 | | Negative | if0 .* | if0 .* |"
+                      % infinite_distance])
     res.check_spf(node="leaf_4_0_2",
                   expect_north_spf=[
-                      r"| 200.0.1.0/24 \(Disagg\) | %d | 411 | | Negative | if0 .* | if0 .* |" % infinite_distance])
+                      r"| 200.0.1.0/24 \(Disagg\) | %d | 411 | | Negative | if0 .* | if0 .* |"
+                      % infinite_distance])
 
 
 def test_neg_disagg_spf_propagation():

--- a/tests/test_neg_disagg_spf_propagation.py
+++ b/tests/test_neg_disagg_spf_propagation.py
@@ -1,0 +1,65 @@
+from rift_expect_session import RiftExpectSession
+from common.constants import infinite_distance
+
+
+def check_spine_positive_next_hops(res):
+    res.check_spf(node="spine_2_1_1",
+                  expect_north_spf=[r"| 200.0.0.0/24 \(Disagg\) | 4 | 122 | | Positive | if3 .* | if3 .* |"])
+    res.check_spf(node="spine_2_1_1",
+                  expect_north_spf=[r"| 200.0.1.0/24 \(Disagg\) | 4 | 122 | | Positive | if3 .* | if3 .* |"])
+    res.check_spf(node="spine_3_1_1",
+                  expect_north_spf=[r"| 200.0.0.0/24 \(Disagg\) | 4 | 122 | | Positive | if3 .* | if3 .* |"])
+    res.check_spf(node="spine_3_1_1",
+                  expect_north_spf=[r"| 200.0.1.0/24 \(Disagg\) | 4 | 122 | | Positive | if3 .* | if3 .* |"])
+    res.check_spf(node="spine_4_1_1",
+                  expect_north_spf=[r"| 200.0.0.0/24 \(Disagg\) | 4 | 122 | | Positive | if3 .* | if3 .* |"])
+    res.check_spf(node="spine_4_1_1",
+                  expect_north_spf=[r"| 200.0.1.0/24 \(Disagg\) | 4 | 122 | | Positive | if3 .* | if3 .* |"])
+
+
+def check_spine_negative_disagg_spf(res):
+    res.check_spf(node="spine_2_1_1",
+                  expect_north_spf=[
+                      r"| 200.0.0.0/24 \(Disagg\) | %d | 121 | | Negative | if2 .* | if2 .* |" % infinite_distance
+                  ])
+    res.check_spf(node="spine_2_1_1", expect_north_spf=[r"| | | 122 | | | if3 .* | if3 .* |"])
+    res.check_spf(node="spine_2_1_1",
+                  expect_north_spf=[
+                      r"| 200.0.1.0/24 \(Disagg\) | %d | 121 | | Negative | if2 .* | if2 .* |" % infinite_distance
+                  ])
+    res.check_spf(node="spine_2_1_1", expect_north_spf=[r"| | | 122 | | | if3 .* | if3 .* |"])
+
+    # res.check_spf(node="spine_3_1_1",
+    #               expect_north_spf=[r"| 200.0.0.0/24 \(Disagg\) | %d | 122 | .* | Negative | if3 .* | if3 .* |"])
+    # res.check_spf(node="spine_3_1_1",
+    #               expect_north_spf=[r"| 200.0.1.0/24 \(Disagg\) | %d | 122 | .* | Negative | if3 .* | if3 .* |"])
+    # res.check_spf(node="spine_4_1_1",
+    #               expect_north_spf=[r"| 200.0.0.0/24 \(Disagg\) | %d | 122 | .* | Negative | if3 .* | if3 .* |"])
+    # res.check_spf(node="spine_4_1_1",
+    #               expect_north_spf=[r"| 200.0.1.0/24 \(Disagg\) | %d | 122 | .* | Negative | if3 .* | if3 .* |"])
+
+
+def test_neg_disagg_spf_propagation():
+    # Disable debug logging for large topologies such as multiple (it makes convergence too slow)
+    res = RiftExpectSession("multiplane", start_converge_secs=45.0, reconverge_secs=30.0,
+                            log_debug=False)
+
+    # Break spine_1_1_1 interfaces connected to tof_1_2_1 (so a next hop should be removed from SPF)
+    res.interface_failure(node="spine_1_1_1", interface="if2", failure="failed")
+
+    # Check that spines lost a next hop
+    check_spine_positive_next_hops(res)
+
+    # Break last spine_1_1_1 interface to reach a fallen leaf situation with first ToF plane
+    res.interface_failure(node="spine_1_1_1", interface="if3", failure="failed")
+
+    # Check that leaf_1_0_1 and leaf_1_0_2 are not reachable
+    # with south SPF of tof_1_1_1 and tof_1_2_2
+    check_spine_negative_disagg_spf(res)
+
+    #
+    # # Check that leaf_1_0_1 and leaf_1_0_2 are reachable
+    # # using special SPF of tof_1_1_1 and tof_1_2_2
+    # check_fall_leafs_sp_spf(res)
+
+    res.stop()

--- a/tests/test_neg_disagg_spf_propagation.py
+++ b/tests/test_neg_disagg_spf_propagation.py
@@ -1,5 +1,5 @@
-from rift_expect_session import RiftExpectSession
 from common.constants import infinite_distance
+from rift_expect_session import RiftExpectSession
 
 
 def check_spine_positive_next_hops(res):
@@ -20,34 +20,72 @@ def check_spine_positive_next_hops(res):
 def check_spine_negative_disagg_spf(res):
     res.check_spf(node="spine_2_1_1",
                   expect_north_spf=[
-                      r"| 200.0.0.0/24 \(Disagg\) | %d | 121 | | Negative | if2 .* | if2 .* |" % infinite_distance
+                      r"| 200.0.0.0/24 \(Disagg\) | %d | 121 | | Negative | if2 .* | if2 .* |\s+"
+                      r"| | | 122 | | | if3 .* | if3 .* |" % infinite_distance
                   ])
-    res.check_spf(node="spine_2_1_1", expect_north_spf=[r"| | | 122 | | | if3 .* | if3 .* |"])
     res.check_spf(node="spine_2_1_1",
                   expect_north_spf=[
-                      r"| 200.0.1.0/24 \(Disagg\) | %d | 121 | | Negative | if2 .* | if2 .* |" % infinite_distance
+                      r"| 200.0.1.0/24 \(Disagg\) | %d | 121 | | Negative | if2 .* | if2 .* |\s+"
+                      r"| | | 122 | | | if3 .* | if3 .* |" % infinite_distance
                   ])
-    res.check_spf(node="spine_2_1_1", expect_north_spf=[r"| | | 122 | | | if3 .* | if3 .* |"])
     res.check_spf(node="spine_3_1_1",
                   expect_north_spf=[
-                      r"| 200.0.0.0/24 \(Disagg\) | %d | 121 | | Negative | if2 .* | if2 .* |" % infinite_distance
+                      r"| 200.0.0.0/24 \(Disagg\) | %d | 121 | | Negative | if2 .* | if2 .* |\s+"
+                      r"| | | 122 | | | if3 .* | if3 .* |" % infinite_distance
                   ])
-    res.check_spf(node="spine_3_1_1", expect_north_spf=[r"| | | 122 | | | if3 .* | if3 .* |"])
     res.check_spf(node="spine_3_1_1",
                   expect_north_spf=[
-                      r"| 200.0.1.0/24 \(Disagg\) | %d | 121 | | Negative | if2 .* | if2 .* |" % infinite_distance
+                      r"| 200.0.1.0/24 \(Disagg\) | %d | 121 | | Negative | if2 .* | if2 .* |\s+"
+                      r"| | | 122 | | | if3 .* | if3 .* |" % infinite_distance
                   ])
-    res.check_spf(node="spine_3_1_1", expect_north_spf=[r"| | | 122 | | | if3 .* | if3 .* |"])
     res.check_spf(node="spine_4_1_1",
                   expect_north_spf=[
-                      r"| 200.0.0.0/24 \(Disagg\) | %d | 121 | | Negative | if2 .* | if2 .* |" % infinite_distance
+                      r"| 200.0.0.0/24 \(Disagg\) | %d | 121 | | Negative | if2 .* | if2 .* |\s+"
+                      r"| | | 122 | | | if3 .* | if3 .* |" % infinite_distance
                   ])
-    res.check_spf(node="spine_4_1_1", expect_north_spf=[r"| | | 122 | | | if3 .* | if3 .* |"])
     res.check_spf(node="spine_4_1_1",
                   expect_north_spf=[
-                      r"| 200.0.1.0/24 \(Disagg\) | %d | 121 | | Negative | if2 .* | if2 .* |" % infinite_distance
+                      r"| 200.0.1.0/24 \(Disagg\) | %d | 121 | | Negative | if2 .* | if2 .* |\s+"
+                      r"| | | 122 | | | if3 .* | if3 .* |" % infinite_distance
                   ])
-    res.check_spf(node="spine_4_1_1", expect_north_spf=[r"| | | 122 | | | if3 .* | if3 .* |"])
+
+def check_leaf_negative_next_hops(res):
+    res.check_spf(node="leaf_2_0_1",
+                  expect_north_spf=[
+                      r"| 200.0.0.0/24 \(Disagg\) | %d | 211 | | Negative | if0 .* | if0 .* |" % infinite_distance])
+    res.check_spf(node="leaf_2_0_1",
+                  expect_north_spf=[
+                      r"| 200.0.1.0/24 \(Disagg\) | %d | 211 | | Negative | if0 .* | if0 .* |" % infinite_distance])
+    res.check_spf(node="leaf_2_0_2",
+                  expect_north_spf=[
+                      r"| 200.0.0.0/24 \(Disagg\) | %d | 211 | | Negative | if0 .* | if0 .* |" % infinite_distance])
+    res.check_spf(node="leaf_2_0_2",
+                  expect_north_spf=[
+                      r"| 200.0.1.0/24 \(Disagg\) | %d | 211 | | Negative | if0 .* | if0 .* |" % infinite_distance])
+    res.check_spf(node="leaf_3_0_1",
+                  expect_north_spf=[
+                      r"| 200.0.0.0/24 \(Disagg\) | %d | 311 | | Negative | if0 .* | if0 .* |" % infinite_distance])
+    res.check_spf(node="leaf_3_0_1",
+                  expect_north_spf=[
+                      r"| 200.0.1.0/24 \(Disagg\) | %d | 311 | | Negative | if0 .* | if0 .* |" % infinite_distance])
+    res.check_spf(node="leaf_3_0_2",
+                  expect_north_spf=[
+                      r"| 200.0.0.0/24 \(Disagg\) | %d | 311 | | Negative | if0 .* | if0 .* |" % infinite_distance])
+    res.check_spf(node="leaf_3_0_2",
+                  expect_north_spf=[
+                      r"| 200.0.1.0/24 \(Disagg\) | %d | 311 | | Negative | if0 .* | if0 .* |" % infinite_distance])
+    res.check_spf(node="leaf_4_0_1",
+                  expect_north_spf=[
+                      r"| 200.0.0.0/24 \(Disagg\) | %d | 411 | | Negative | if0 .* | if0 .* |" % infinite_distance])
+    res.check_spf(node="leaf_4_0_1",
+                  expect_north_spf=[
+                      r"| 200.0.1.0/24 \(Disagg\) | %d | 411 | | Negative | if0 .* | if0 .* |" % infinite_distance])
+    res.check_spf(node="leaf_4_0_2",
+                  expect_north_spf=[
+                      r"| 200.0.0.0/24 \(Disagg\) | %d | 411 | | Negative | if0 .* | if0 .* |" % infinite_distance])
+    res.check_spf(node="leaf_4_0_2",
+                  expect_north_spf=[
+                      r"| 200.0.1.0/24 \(Disagg\) | %d | 411 | | Negative | if0 .* | if0 .* |" % infinite_distance])
 
 
 def test_neg_disagg_spf_propagation():
@@ -58,19 +96,17 @@ def test_neg_disagg_spf_propagation():
     # Break spine_1_1_1 interfaces connected to tof_1_2_1 (so a next hop should be removed from SPF)
     res.interface_failure(node="spine_1_1_1", interface="if2", failure="failed")
 
-    # Check that spines lost a next hop
+    # Check that spines lost a positive next hop for the negative disaggregated prefixes
     check_spine_positive_next_hops(res)
 
     # Break last spine_1_1_1 interface to reach a fallen leaf situation with first ToF plane
     res.interface_failure(node="spine_1_1_1", interface="if3", failure="failed")
 
-    # Check that leaf_1_0_1 and leaf_1_0_2 are not reachable
-    # with south SPF of tof_1_1_1 and tof_1_2_2
+    # Check that each spine loses all the positive next hops for the negative disaggregated prefixes
+    # and computes only negative next hops
     check_spine_negative_disagg_spf(res)
 
-    #
-    # # Check that leaf_1_0_1 and leaf_1_0_2 are reachable
-    # # using special SPF of tof_1_1_1 and tof_1_2_2
-    # check_fall_leafs_sp_spf(res)
+    # Check that each leaf computed a negative next hops for the negative disaggregated prefixes
+    check_leaf_negative_next_hops(res)
 
     res.stop()

--- a/tests/test_neg_disagg_spf_propagation.py
+++ b/tests/test_neg_disagg_spf_propagation.py
@@ -28,15 +28,26 @@ def check_spine_negative_disagg_spf(res):
                       r"| 200.0.1.0/24 \(Disagg\) | %d | 121 | | Negative | if2 .* | if2 .* |" % infinite_distance
                   ])
     res.check_spf(node="spine_2_1_1", expect_north_spf=[r"| | | 122 | | | if3 .* | if3 .* |"])
-
-    # res.check_spf(node="spine_3_1_1",
-    #               expect_north_spf=[r"| 200.0.0.0/24 \(Disagg\) | %d | 122 | .* | Negative | if3 .* | if3 .* |"])
-    # res.check_spf(node="spine_3_1_1",
-    #               expect_north_spf=[r"| 200.0.1.0/24 \(Disagg\) | %d | 122 | .* | Negative | if3 .* | if3 .* |"])
-    # res.check_spf(node="spine_4_1_1",
-    #               expect_north_spf=[r"| 200.0.0.0/24 \(Disagg\) | %d | 122 | .* | Negative | if3 .* | if3 .* |"])
-    # res.check_spf(node="spine_4_1_1",
-    #               expect_north_spf=[r"| 200.0.1.0/24 \(Disagg\) | %d | 122 | .* | Negative | if3 .* | if3 .* |"])
+    res.check_spf(node="spine_3_1_1",
+                  expect_north_spf=[
+                      r"| 200.0.0.0/24 \(Disagg\) | %d | 121 | | Negative | if2 .* | if2 .* |" % infinite_distance
+                  ])
+    res.check_spf(node="spine_3_1_1", expect_north_spf=[r"| | | 122 | | | if3 .* | if3 .* |"])
+    res.check_spf(node="spine_3_1_1",
+                  expect_north_spf=[
+                      r"| 200.0.1.0/24 \(Disagg\) | %d | 121 | | Negative | if2 .* | if2 .* |" % infinite_distance
+                  ])
+    res.check_spf(node="spine_3_1_1", expect_north_spf=[r"| | | 122 | | | if3 .* | if3 .* |"])
+    res.check_spf(node="spine_4_1_1",
+                  expect_north_spf=[
+                      r"| 200.0.0.0/24 \(Disagg\) | %d | 121 | | Negative | if2 .* | if2 .* |" % infinite_distance
+                  ])
+    res.check_spf(node="spine_4_1_1", expect_north_spf=[r"| | | 122 | | | if3 .* | if3 .* |"])
+    res.check_spf(node="spine_4_1_1",
+                  expect_north_spf=[
+                      r"| 200.0.1.0/24 \(Disagg\) | %d | 121 | | Negative | if2 .* | if2 .* |" % infinite_distance
+                  ])
+    res.check_spf(node="spine_4_1_1", expect_north_spf=[r"| | | 122 | | | if3 .* | if3 .* |"])
 
 
 def test_neg_disagg_spf_propagation():

--- a/tests/test_neg_disagg_ties.py
+++ b/tests/test_neg_disagg_ties.py
@@ -1,6 +1,7 @@
 from rift_expect_session import RiftExpectSession
 from common.constants import infinite_distance
 
+
 def check_neg_tie_in_tof(res):
     patterns = [
         r"| South | 121 | Neg-Dis-Prefix | .* | .* | .* | Neg-Dis-Prefix: 200.0.0.0/24 |",
@@ -14,6 +15,7 @@ def check_neg_tie_in_tof(res):
         r"| | | | | | | Neg-Dis-Prefix: 200.0.1.0/24 |",
         r"| | | | | | |   Metric: %d |" % infinite_distance]
     res.check_tie_in_db("tof_1_2_2", "south", "122", "neg-dis-prefix", patterns)
+
 
 def check_neg_tie_in_spines(res):
     for pod_n in range(2, 5):
@@ -31,18 +33,20 @@ def check_neg_tie_in_spines(res):
             r"| | | | | | |   Metric: %d |" % infinite_distance]
         res.check_tie_in_db(node, "south", "122", "neg-dis-prefix", patterns)
 
+
 def check_neg_tie_in_leafs(res):
     for pod_n in range(2, 5):
         originator = "%d11" % pod_n
         patterns = [
             r"| South | %s | Neg-Dis-Prefix | .* | .* | .* | Neg-Dis-Prefix: 200.0.0.0/24 |" \
-                % originator,
+            % originator,
             r"| | | | | | |   Metric: %d |" % infinite_distance,
             r"| | | | | | | Neg-Dis-Prefix: 200.0.1.0/24 |",
             r"| | | | | | |   Metric: %d |" % infinite_distance]
         for leaf_n in range(1, 3):
             node = "leaf_%d_0_%d" % (pod_n, leaf_n)
             res.check_tie_in_db(node, "south", originator, "neg-dis-prefix", patterns)
+
 
 def test_neg_disagg_ties():
     # Disable debug logging for large topologies such as multiple (it makes convergence too slow)


### PR DESCRIPTION
This PR adds the support for Negative Prefixes in SPF run. 

In particular, negative TIE prefixes are added as candidate nodes during the SPF run (as already happens for normal/positive prefixes).

In this way each node computes negative next hops for negative prefixes.