### PR TITLE
requirements-3-567.txt: use rsa 4.1

### DIFF
--- a/requirements-3-567.txt
+++ b/requirements-3-567.txt
@@ -35,7 +35,7 @@ pytricia==1.0.1
 PyYAML==4.2b1
 requests==2.20.0
 rope==0.11.0
-rsa==3.4.2
+rsa==4.1
 s3transfer==0.3.3
 six==1.11.0
 sortedcontainers==2.0.4


### PR DESCRIPTION
Use newer rsa to address CVE-2020-13757
Vulnerable versions: < 4.1
Patched version: 4.1

Python-RSA 4.0 ignores leading '\0' bytes during decryption of ciphertext.
This could conceivably have a security-relevant impact, e.g., by helping an
attacker to infer that an application uses Python-RSA, or if the length of
accepted ciphertext affects application behavior (such as by causing
excessive memory allocation).