### PR TITLE
Remove 'spine' from valid strings, add 'leaf-2-leaf'

### DIFF
--- a/rift/config.py
+++ b/rift/config.py
@@ -206,8 +206,8 @@ class RiftValidator(cerberus.Validator):
             return 1 <= port <= 65535
 
     def _validate_type_level(self, value):
-        if isinstance(value, str) and value.lower() in ['undefined', 'leaf',
-                                                        'spine', 'top-of-fabric']:
+        if isinstance(value, str) and value.lower() in ['undefined', 'leaf', 'leaf-2-leaf',
+                                                        'top-of-fabric']:
             return True
         try:
             level = int(value)


### PR DESCRIPTION
'spine' fails upon deployment, 'leaf-2-leaf' was missing